### PR TITLE
Fixed file extensions used in JSON for Gold ART Token

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -3412,8 +3412,8 @@
     },
     {
         "name": "Gold ART Token",
-        "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/goldarttoken.jpg",
-        "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/goldarttoken_lg.jpg",
+        "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/goldarttoken.png",
+        "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/goldarttoken_lg.png",
         "symbol": "ART",
         "account": "goldarttoken",
         "chain": "wax"


### PR DESCRIPTION
The files are supposed to be png, not jpg. Thank you!

## How to add token?

- [ ] Add metadata to [`tokens.json`](tokens.json)

```json
{
    "name": "<NAME>",
    "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/<SYMBOL>.png",
    "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/<SYMBOL>.png",
    "symbol": "<SYMBOL>",
    "account": "<CONTRACT NAME>",
    "chain": "eos"
}
```

- [ ] Add token logo `*.png` to [`./logos`](./logos) folder
