### PR TITLE
Fix mistyped logo path for "ESB - Breeders Essentia" token

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -1,8 +1,8 @@
 [
      {
         "name": "ESB - Breeders Essentia",
-        "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/logos/breeders_essentia_logo_256x256.jpg",
-        "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/logos/breeders_essentia_logo_1200x1200.jpg",
+        "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/breeders_essentia_logo_256x256.jpg",
+        "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/breeders_essentia_logo_1200x1200.jpg",
         "symbol": "ESB",
         "account": "esbcontracts",
         "chain": "wax"


### PR DESCRIPTION
## How to add token?

- [ ] Add metadata to [`tokens.json`](tokens.json)

```json
{
    "name": "<NAME>",
    "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/<SYMBOL>.png",
    "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/<SYMBOL>.png",
    "symbol": "<SYMBOL>",
    "account": "<CONTRACT NAME>",
    "chain": "eos"
}
```

- [ ] Add token logo `*.png` to [`./logos`](./logos) folder
