### PR TITLE
Corrected BLUx -> BLUX (this is our project token)

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -3375,7 +3375,7 @@
         "chain": "wax"
     },
     {
-        "name": "BLUx",
+        "name": "BLUX",
         "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/blux.png",
         "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/blux-lg.png",
         "symbol": "BLUX",


### PR DESCRIPTION
We have changed the name officially from BLUx to BLUX and would like to reflect that change in this repo.

## How to add token?

- [ ] Add metadata to [`tokens.json`](tokens.json)

```json
{
    "name": "<NAME>",
    "logo": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/<SYMBOL>.png",
    "logo_lg": "https://raw.githubusercontent.com/eoscafe/eos-airdrops/master/logos/<SYMBOL>.png",
    "symbol": "<SYMBOL>",
    "account": "<CONTRACT NAME>",
    "chain": "eos"
}
```

- [ ] Add token logo `*.png` to [`./logos`](./logos) folder
